### PR TITLE
Fatal error in dashboard

### DIFF
--- a/dist/contributor-orientation-tool/src/WPCOTool/Admin/Options.php
+++ b/dist/contributor-orientation-tool/src/WPCOTool/Admin/Options.php
@@ -148,9 +148,9 @@ class Options {
 		$values = $this->get_values();
 		$teams = Plugin::get_form_config( 'teams.php' );
 
-		foreach ( $teams as $id => $name ) {
+		foreach ( $teams as $id => $team ) {
 
-			$team = new Team( $id, $name );
+			$team = new Team( $id, $team['name'], $team['description'], $team['icon'], $team['url'] );
 			$team_id = $team->get_id();
 
 			printf(


### PR DESCRIPTION
Team parameters are changed from 2 strings to 5. Value in foreach loop is now associative array and passing it as a second parameter was throwing fatal error because it was expecting string.